### PR TITLE
Add notes about Imgur's built-in /zip route

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ Imgur Album Downlaoder
 A Pure JS webapp to download entire or parts of Imgur albums.
 
 Go to http://dschep.github.io/imgur-album-downloader to use it!
+
+Note: Large albums or albums containing very high resolution photos
+might not work, depending on how much RAM your system has. You can
+download whole albums natively on Imgur by appending `/zip` to the URL.

--- a/css/app.css
+++ b/css/app.css
@@ -71,12 +71,12 @@ body > div {
   height: 100%;
   /* Negative indent footer by it's height */
 
-  margin: 0 auto -60px;
+  margin: 0 auto -100px;
 }
 /* Set the fixed height of the footer here */
 #push,
 #footer {
-  height: 60px;
+  height: 100px;
 }
 #footer {
   background-color: #111;

--- a/index.html
+++ b/index.html
@@ -25,6 +25,9 @@
             Source on <a href="https://github.com/dschep/imgur-album-downloader">
                 <i class="icon-github"></i></a>
             </p>
+            <p class="muted">
+            Tab crashing during the download? Try appending <tt>/zip</tt> to the Imgur album URL.
+            </p>
         </div>
     </footer>
     <script>


### PR DESCRIPTION
Large enough albums can crash the browser tab running the webapp by exhausting available RAM, as I discovered last week, so it's good to tell the user that there's an alternative.

Adds a note to the app footer (and tweaks the height so the extra line fits), and to the README for users who click through.

Not a fix for #1, but mitigates it somewhat by presenting a workaround if problems occur.