### PR TITLE
Use protocol-relative URI for image thumbnails

### DIFF
--- a/partials/album.html
+++ b/partials/album.html
@@ -25,7 +25,7 @@
                     <input type="checkbox" name="{{image.id}}"
                         id="{{image.id}}" ng-model="image.selected">
                     <label for="{{image.id}}">
-                        <img src="http://i.imgur.com/{{image.id}}b.jpg">
+                        <img src="//i.imgur.com/{{image.id}}b.jpg">
                     </label>
                 </li>
             </ul>


### PR DESCRIPTION
Using protocol-relative URIs to handle securely loading image thumbnails going forward.

This should plug the insecure asset loading that is currently occurring in the application.